### PR TITLE
expect implementations to return empty settings for missing sections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+unreleased
+==========
+
+- Removed the ``plaster.NoSectionError`` exception. It's expected that
+  individual loaders should return an empty dictionary of settings in the
+  case that a section cannot be found.
+  See https://github.com/Pylons/plaster/pull/12
+
+- Expect the ``wsgi`` protocol to raise ``LookupError`` exceptions when
+  a named wsgi component cannot be found.
+  See https://github.com/Pylons/plaster/pull/12
+
 0.3 (2017-03-27)
 ================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,6 +57,3 @@ Exceptions
 
 .. autoexception:: MultipleLoadersFound
     :members:
-
-.. autoexception:: NoSectionError
-    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,7 +170,7 @@ In this example the importable ``myapp.Loader`` class will be used as :class:`pl
 
         def get_settings(self, section=None, defaults=None):
             # fallback to the fragment from config_uri if no section is given
-            if section is None:
+            if not section:
                 section = self.uri.fragment
             # if section is still none we could fallback to some
             # loader-specific default
@@ -182,8 +182,6 @@ In this example the importable ``myapp.Loader`` class will be used as :class:`pl
                 result.update({'a': 1})
             elif section == 'yourapp':
                 result.update({'b': 1})
-            else:
-                raise plaster.NoSectionError(section)
             return result
 
 This loader may then be used:

--- a/src/plaster/__init__.py
+++ b/src/plaster/__init__.py
@@ -5,7 +5,6 @@ from .exceptions import (
     InvalidURI,
     LoaderNotFound,
     MultipleLoadersFound,
-    NoSectionError,
     PlasterError,
 )
 from .interfaces import (

--- a/src/plaster/exceptions.py
+++ b/src/plaster/exceptions.py
@@ -4,21 +4,6 @@ class PlasterError(Exception):
     """
 
 
-class NoSectionError(PlasterError, ValueError):
-    """
-    Raised by a :class:`plaster.ILoader` which cannot find a section.
-
-    :ivar section: The name of the section that does not exist.
-
-    """
-    def __init__(self, section=None, message=None):
-        if message is None:
-            message = 'Could not find requested section "{0}".'.format(section)
-        super(NoSectionError, self).__init__(message)
-        self.message = message
-        self.section = section
-
-
 class InvalidURI(PlasterError, ValueError):
     """
     Raised by :func:`plaster.parse_uri` when failing to parse a ``config_uri``.

--- a/src/plaster/interfaces.py
+++ b/src/plaster/interfaces.py
@@ -46,9 +46,10 @@ class ILoader(object):
             ``defaults`` may be overridden by the loader prior to returning
             the final configuration dictionary.
 
-        :returns: A ``dict`` of settings.
-        :raises plaster.NoSectionError: If a section name cannot be determined or
-            a section of the determined name cannot be found.
+        :returns: A ``dict`` of settings. This should return a dictionary
+            object even if the section is missing.
+        :raises ValueError: If a section name is missing and cannot be
+            determined from the ``config_uri``.
 
         """
 

--- a/src/plaster/loaders.py
+++ b/src/plaster/loaders.py
@@ -52,9 +52,8 @@ def get_settings(config_uri, section=None, defaults=None):
         may be overridden by the loader prior to returning the final
         configuration dictionary.
 
-    :returns: A ``dict`` of settings.
-    :raises plaster.NoSectionError: If a section name cannot be determined or
-        a section of the determined name cannot be found.
+    :returns: A ``dict`` of settings. This should return a dictionary object
+        even if no data is available.
 
     """
     loader = get_loader(config_uri)

--- a/src/plaster/protocols.py
+++ b/src/plaster/protocols.py
@@ -27,6 +27,9 @@ class IWSGIProtocol(object):
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
 
+        :raises ValueError: If a WSGI application cannot be found by the
+            specified name.
+
         """
 
     @abc.abstractmethod
@@ -50,6 +53,9 @@ class IWSGIProtocol(object):
             settings and support variable interpolation. Any values in
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
+
+        :raises ValueError: If a WSGI application cannot be found by the
+            specified name.
 
         """
 
@@ -78,6 +84,9 @@ class IWSGIProtocol(object):
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
 
+        :raises ValueError: If a WSGI filter cannot be found by the
+            specified name.
+
         """
 
     @abc.abstractmethod
@@ -102,5 +111,8 @@ class IWSGIProtocol(object):
             settings and support variable interpolation. Any values in
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
+
+        :raises ValueError: If a WSGI server cannot be found by the
+            specified name.
 
         """

--- a/src/plaster/protocols.py
+++ b/src/plaster/protocols.py
@@ -27,7 +27,7 @@ class IWSGIProtocol(object):
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
 
-        :raises ValueError: If a WSGI application cannot be found by the
+        :raises LookupError: If a WSGI application cannot be found by the
             specified name.
 
         """
@@ -54,7 +54,7 @@ class IWSGIProtocol(object):
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
 
-        :raises ValueError: If a WSGI application cannot be found by the
+        :raises LookupError: If a WSGI application cannot be found by the
             specified name.
 
         """
@@ -84,7 +84,7 @@ class IWSGIProtocol(object):
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
 
-        :raises ValueError: If a WSGI filter cannot be found by the
+        :raises LookupError: If a WSGI filter cannot be found by the
             specified name.
 
         """
@@ -112,7 +112,7 @@ class IWSGIProtocol(object):
             ``defaults`` may be overridden by the loader prior to returning the
             final configuration dictionary.
 
-        :raises ValueError: If a WSGI server cannot be found by the
+        :raises LookupError: If a WSGI server cannot be found by the
             specified name.
 
         """

--- a/tests/fake_packages/app1/app1/loaders.py
+++ b/tests/fake_packages/app1/app1/loaders.py
@@ -30,7 +30,7 @@ class LoaderBase(plaster.ILoader):
         try:
             result.update(_SECTIONS[section])
         except KeyError:
-            raise plaster.NoSectionError(section)
+            pass
         return result
 
     def setup_logging(self, defaults=None):

--- a/tests/fake_packages/app2/app2/loaders.py
+++ b/tests/fake_packages/app2/app2/loaders.py
@@ -29,7 +29,7 @@ class LoaderBase(plaster.ILoader):
         try:
             result.update(_SECTIONS[section])
         except KeyError:
-            raise plaster.NoSectionError(section)
+            pass
         return result
 
     def setup_logging(self, defaults=None):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,21 +1,3 @@
-class TestNoSectionError(object):
-    def _makeOne(self, *args, **kwargs):
-        from plaster.exceptions import NoSectionError
-        return NoSectionError(*args, **kwargs)
-
-    def test_it(self):
-        exc = self._makeOne('foo')
-        assert isinstance(exc, ValueError)
-        assert exc.section == 'foo'
-        assert exc.message == 'Could not find requested section "foo".'
-
-    def test_it_overrides_message(self):
-        exc = self._makeOne('foo', message='bar')
-        assert isinstance(exc, ValueError)
-        assert exc.section == 'foo'
-        assert exc.message == 'bar'
-
-
 class TestInvalidURI(object):
     def _makeOne(self, *args, **kwargs):
         from plaster.exceptions import InvalidURI

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -156,9 +156,8 @@ class Test_get_settings(object):
         assert result == {'foo': 'bar', 'baz': 'foo'}
 
     def test_invalid_section(self):
-        from plaster.exceptions import NoSectionError
-        with pytest.raises(NoSectionError):
-            self._callFUT('development.ini', 'c')
+        result = self._callFUT('development.ini', 'c')
+        assert result == {}
 
     def test_it_bad(self):
         with pytest.raises(Exception):


### PR DESCRIPTION
If a user cares about whether a section actually exists or not they can check `get_sections`.

As I've been updated pyramid's scripts it's proven a bit tedious and unnecessary to handle the `NoSectionError` and I'm failing to see its usefulness.