### PR TITLE
file schemes

### DIFF
--- a/src/plaster/loaders.py
+++ b/src/plaster/loaders.py
@@ -142,14 +142,14 @@ def find_loaders(scheme, protocols=None):
     scheme = scheme.lower()
 
     # if a distribution is specified then it overrides the default search
-    parts = scheme.rsplit('+', 1)
+    parts = scheme.split('+', 1)
     if len(parts) == 2:
         try:
-            distro = pkg_resources.get_distribution(parts[1])
+            distro = pkg_resources.get_distribution(parts[0])
         except pkg_resources.DistributionNotFound:
             pass
         else:
-            ep = _find_ep_in_dist(distro, parts[0], matching_groups)
+            ep = _find_ep_in_dist(distro, parts[1], matching_groups)
 
             # if we got one or more loaders from a specific distribution
             # then they override everything else so we'll just return them
@@ -188,7 +188,7 @@ def _find_ep_in_dist(distro, scheme, groups):
 class EntryPointLoaderInfo(ILoaderInfo):
     def __init__(self, ep, protocols=None):
         self.entry_point = ep
-        self.scheme = '{0}+{1}'.format(ep.name, ep.dist.project_name)
+        self.scheme = '{0}+{1}'.format(ep.dist.project_name, ep.name)
         self.protocols = protocols
 
         self._factory = None

--- a/src/plaster/uri.py
+++ b/src/plaster/uri.py
@@ -102,6 +102,10 @@ def parse_uri(config_uri):
         if scheme.startswith('.'):
             scheme = scheme[1:]
 
+        # tag uris coming from file extension as file+scheme
+        if scheme:
+            scheme = 'file+' + scheme
+
     query = parts.query if parts.query else None
     options = OrderedDict()
     if query:

--- a/tests/fake_packages/app1/app1.egg-info/entry_points.txt
+++ b/tests/fake_packages/app1/app1.egg-info/entry_points.txt
@@ -1,20 +1,26 @@
 [other.loader]
 ini = app1.loaders:WontBeLoaded
 
+[plaster.dummy1_loader_factory]
+file+ini = app1.loaders:INIWSGILoader
+ini = app1.loaders:INIWSGILoader
+
+[plaster.dummy2_loader_factory]
+file+ini = app1.loaders:INILoader
+ini = app1.loaders:INILoader
+
 [plaster.loader_factory]
 bad = app1.loaders:BadLoader
 broken = app1.loaders.BadLoader
 conf = app1.loaders:ConfLoader
 dup = app1.loaders:DuplicateLoader
+file+conf = app1.loaders:ConfLoader
+file+ini = app1.loaders:INIWSGILoader
+file+yaml = app1.loaders:YAMLLoader
 ini = app1.loaders:INIWSGILoader
-yaml = app1.loaders:YAMLLoader
 yaml+foo = app1.loaders:YAMLFooLoader
 
 [plaster.wsgi_loader_factory]
+file+ini = app1.loaders:INIWSGILoader
 ini = app1.loaders:INIWSGILoader
 
-[plaster.dummy1_loader_factory]
-ini = app1.loaders:INIWSGILoader
-
-[plaster.dummy2_loader_factory]
-ini = app1.loaders:INILoader

--- a/tests/fake_packages/app1/app1/loaders.py
+++ b/tests/fake_packages/app1/app1/loaders.py
@@ -71,7 +71,7 @@ class YAMLFooLoader(LoaderBase):
 
 
 class DuplicateLoader(LoaderBase):
-    entry_point_key = 'dup+app1'
+    entry_point_key = 'app1+dup'
 
 
 class BadLoader(object):

--- a/tests/fake_packages/app1/setup.py
+++ b/tests/fake_packages/app1/setup.py
@@ -7,8 +7,10 @@ setup(
     entry_points={
         'plaster.loader_factory': [
             'conf=app1.loaders:ConfLoader',
+            'file+conf=app1.loaders:ConfLoader',
             'ini=app1.loaders:INIWSGILoader',
-            'yaml=app1.loaders:YAMLLoader',
+            'file+ini=app1.loaders:INIWSGILoader',
+            'file+yaml=app1.loaders:YAMLLoader',
             'yaml+foo=app1.loaders:YAMLFooLoader',
             'dup=app1.loaders:DuplicateLoader',
             'bad=app1.loaders:BadLoader',
@@ -16,12 +18,15 @@ setup(
         ],
         'plaster.wsgi_loader_factory': [
             'ini=app1.loaders:INIWSGILoader',
+            'file+ini=app1.loaders:INIWSGILoader',
         ],
         'plaster.dummy1_loader_factory': [
             'ini=app1.loaders:INIWSGILoader',
+            'file+ini=app1.loaders:INIWSGILoader',
         ],
         'plaster.dummy2_loader_factory': [
             'ini=app1.loaders:INILoader',
+            'file+ini=app1.loaders:INILoader',
         ],
         'other.loader': [
             'ini=app1.loaders:WontBeLoaded',

--- a/tests/fake_packages/app2/app2/loaders.py
+++ b/tests/fake_packages/app2/app2/loaders.py
@@ -42,4 +42,4 @@ class YAMLBarLoader(LoaderBase):
 
 
 class DuplicateLoader(LoaderBase):
-    entry_point_key = 'dup+app2'
+    entry_point_key = 'app2+dup'

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -15,7 +15,7 @@ class Test_get_loader(object):
         assert loader.entry_point_key == 'conf'
 
     def test_scheme_uri_for_pkg(self):
-        loader = self._callFUT('conf+app1://')
+        loader = self._callFUT('app1+conf://')
         assert loader.entry_point_key == 'conf'
 
     def test_path_with_extension(self):
@@ -32,12 +32,12 @@ class Test_get_loader(object):
             self._callFUT('dup://development.ini')
 
     def test_dedup_app1(self):
-        loader = self._callFUT('dup+app1://development.ini')
-        assert loader.entry_point_key == 'dup+app1'
+        loader = self._callFUT('app1+dup://development.ini')
+        assert loader.entry_point_key == 'app1+dup'
 
     def test_dedup_app2(self):
-        loader = self._callFUT('dup+app2://development.ini')
-        assert loader.entry_point_key == 'dup+app2'
+        loader = self._callFUT('app2+dup://development.ini')
+        assert loader.entry_point_key == 'app2+dup'
 
     def test_other_groups(self):
         from plaster.exceptions import LoaderNotFound
@@ -72,21 +72,21 @@ class Test_find_loaders(object):
     def test_simple_uri(self):
         loaders = self._callFUT('conf')
         assert len(loaders) == 1
-        assert loaders[0].scheme == 'conf+app1'
+        assert loaders[0].scheme == 'app1+conf'
         loader = loaders[0].load('development.conf')
         assert loader.entry_point_key == 'conf'
 
     def test_case_insensitive_scheme(self):
         loaders = self._callFUT('CONF')
         assert len(loaders) == 1
-        assert loaders[0].scheme == 'conf+app1'
+        assert loaders[0].scheme == 'app1+conf'
         loader = loaders[0].load('development.conf')
         assert loader.entry_point_key == 'conf'
 
     def test_scheme_specific_uri(self):
         loaders = self._callFUT('ini')
         assert len(loaders) == 1
-        assert loaders[0].scheme == 'ini+app1'
+        assert loaders[0].scheme == 'app1+ini'
         loader = loaders[0].load('development.ini')
         assert loader.entry_point_key == 'ini+wsgi'
 
@@ -94,8 +94,8 @@ class Test_find_loaders(object):
         loaders = self._callFUT('dup')
         assert len(loaders) == 2
         schemes = set([l.scheme for l in loaders])
-        assert 'dup+app1' in schemes
-        assert 'dup+app2' in schemes
+        assert 'app1+dup' in schemes
+        assert 'app2+dup' in schemes
 
     def test_one_protocol(self):
         loaders = self._callFUT('ini', protocols=['wsgi'])

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -46,7 +46,7 @@ class Test_get_loader(object):
 
     def test_bad(self):
         from app1.loaders import BadLoader
-        loader = self._callFUT('development.bad')
+        loader = self._callFUT('bad:development')
         assert isinstance(loader, BadLoader)
 
     def test_it_broken(self):

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -38,8 +38,8 @@ class TestURL(object):
         assert uri.fragment == 'main'
 
     def test_url_for_file(self):
-        uri = self._callFUT('ini+pastedeploy://development.ini')
-        assert uri.scheme == 'ini+pastedeploy'
+        uri = self._callFUT('pastedeploy+ini://development.ini')
+        assert uri.scheme == 'pastedeploy+ini'
         assert uri.path == 'development.ini'
         assert uri.options == {}
         assert uri.fragment == ''

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -9,7 +9,7 @@ class TestURL(object):
 
     def test_relative_path(self):
         uri = self._callFUT('development.ini')
-        assert uri.scheme == 'ini'
+        assert uri.scheme == 'file+ini'
         assert uri.path == 'development.ini'
         assert uri.options == {}
         assert uri.fragment == ''
@@ -17,7 +17,7 @@ class TestURL(object):
     def test_absolute_path(self):
         path = os.path.abspath('/path/to/development.ini')
         uri = self._callFUT(path)
-        assert uri.scheme == 'ini'
+        assert uri.scheme == 'file+ini'
         assert uri.path == path
         assert uri.options == {}
         assert uri.fragment == ''
@@ -25,7 +25,7 @@ class TestURL(object):
     def test_absolute_path_with_fragment(self):
         path = os.path.abspath('/path/to/development.ini')
         uri = self._callFUT(path + '?a=b&c=d#main')
-        assert uri.scheme == 'ini'
+        assert uri.scheme == 'file+ini'
         assert uri.path == path
         assert uri.options == {'a': 'b', 'c': 'd'}
         assert uri.fragment == 'main'
@@ -51,19 +51,19 @@ class TestURL(object):
 
     def test___str__(self):
         uri = self._callFUT('development.ini')
-        assert str(uri) == 'ini://development.ini'
+        assert str(uri) == 'file+ini://development.ini'
 
     def test___str___with_options(self):
         uri = self._callFUT('development.ini?a=b&c=d')
-        assert str(uri) == 'ini://development.ini?a=b&c=d'
+        assert str(uri) == 'file+ini://development.ini?a=b&c=d'
 
     def test___str___with_fragment(self):
         uri = self._callFUT('development.ini#main')
-        assert str(uri) == 'ini://development.ini#main'
+        assert str(uri) == 'file+ini://development.ini#main'
 
     def test___repr___(self):
         uri = self._callFUT('development.ini#main')
-        assert repr(uri) == 'PlasterURL(\'ini://development.ini#main\')'
+        assert repr(uri) == 'PlasterURL(\'file+ini://development.ini#main\')'
 
     def test_returns_same_instance(self):
         uri1 = self._callFUT('development.ini')


### PR DESCRIPTION
- Any schemes derived from the file extension will have the `file+` prefix.

- Also reverse the scheme order such that the package override is done as a prefix instead of suffix. For example `plaster_pastedeploy+foo` instead of `foo+plaster_pastedeploy`.

fixes #15 