### PR TITLE
Fix messaging around the InvalidURI exception

### DIFF
--- a/src/plaster/uri.py
+++ b/src/plaster/uri.py
@@ -115,7 +115,7 @@ def parse_uri(config_uri):
     if not scheme:
         raise InvalidURI(config_uri, (
             'Could not determine the loader scheme for the supplied '
-            'config_uri.'))
+            'config_uri "{0}"'.format(config_uri)))
 
     return PlasterURL(
         scheme=scheme,


### PR DESCRIPTION
The default behavior of InvalidURI would display the config_uri, but if you specify a message, that config_uri is not displayed, making troubleshooting hard.  This adds `config_uri` to the exception message so you can tell what is broken.  In my case it was
`pshell -p bpython my.ini`  which needed to be `pshell my.ini -p bpython`
The exception message before this change didn't tell you what you needed to know (that `-p` was the `config_uri`)