### PR TITLE
Make flake8-bugbear happy

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,4 @@ Contributors
 - Michael Merickel (2016-06-12)
 - Steve Piercy (2017-08-31)
 - Bert JW Regeer (2019-05-31)
+- Karl O. Pinc (2024-04-14)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -55,7 +55,7 @@ class Test_get_loader:
         assert isinstance(loader, BadLoader)
 
     def test_it_broken(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match=r"file\+broken"):
             self._callFUT("development.broken")
 
     def test_it_notfound(self):
@@ -137,7 +137,7 @@ class Test_get_sections:
         assert set(result) == {"a", "b"}
 
     def test_it_bad(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match=r"file\+bad"):
             self._callFUT("development.bad")
 
 
@@ -169,7 +169,7 @@ class Test_get_settings:
         assert result == {}
 
     def test_it_bad(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match=r"file\+bad"):
             self._callFUT("development.bad")
 
 
@@ -195,5 +195,5 @@ class Test_setup_logging:
         self._callFUT("development.ini#a")
 
     def test_it_bad(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="BadLoader"):
             self._callFUT("bad://development.ini")


### PR DESCRIPTION
flake8-bugbear declares: 

`B017 'assertRaises(Exception)' and 'pytest.raises(Exception)' should be considered evil.`

This eliminates the complaint.

---

Again, it is unclear what the best match re is, or the more specific exception trap is.

The last hunk (match="BadLoader") produces the exception:

`<ExceptionInfo AttributeError("'BadLoader' object has no attribute 'setup_logging'") tblen=3>`

The earlier 3 hunks produce exceptions that _rep_ like (differing only in the scheme reported):

`<ExceptionInfo LoaderNotFound('Could not find a matching loader for the scheme "file+bad".') tblen=4>`

I believe that match re-s given are a good representation of the expected error,s but I did the obvious thing and didn't think too deeply.