### PR TITLE
Add "raw" keyword-only parameter to Loader.get_settings()

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,4 @@ Contributors
 - Michael Merickel (2016-06-12)
 - Steve Piercy (2017-08-31)
 - Bert JW Regeer (2019-05-31)
+- Karl O. Pinc (2024-04-14)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -176,7 +176,7 @@ If the loader should be found automatically via file extension then it should br
         def get_sections(self):
             return ['myapp', 'yourapp']
 
-        def get_settings(self, section=None, defaults=None):
+        def get_settings(self, section=None, defaults=None, raw=False):
             # fallback to the fragment from config_uri if no section is given
             if not section:
                 section = self.uri.fragment
@@ -184,7 +184,7 @@ If the loader should be found automatically via file extension then it should br
             # loader-specific default
 
             result = {}
-            if defaults is not None:
+            if not raw and defaults is not None:
                 result.update(defaults)
             if section == 'myapp':
                 result.update({'a': 1})

--- a/src/plaster/interfaces.py
+++ b/src/plaster/interfaces.py
@@ -29,7 +29,7 @@ class ILoader(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def get_settings(self, section=None, defaults=None):
+    def get_settings(self, section=None, defaults=None, *, raw=False):
         """
         Load the settings for the named ``section``.
 
@@ -42,6 +42,9 @@ class ILoader(metaclass=abc.ABCMeta):
             settings and support variable interpolation. Any values in
             ``defaults`` may be overridden by the loader prior to returning
             the final configuration dictionary.
+
+        :param raw: when not True, return the section without interpolation,
+            application of defaults, or other alteration.
 
         :returns: A ``dict`` of settings. This should return a dictionary
             object even if the section is missing.

--- a/src/plaster/loaders.py
+++ b/src/plaster/loaders.py
@@ -31,7 +31,7 @@ def get_sections(config_uri):
     return loader.get_sections()
 
 
-def get_settings(config_uri, section=None, defaults=None):
+def get_settings(config_uri, section=None, defaults=None, *, raw=False):
     """
     Load the settings from a named section.
 
@@ -53,13 +53,16 @@ def get_settings(config_uri, section=None, defaults=None):
         may be overridden by the loader prior to returning the final
         configuration dictionary.
 
+    :param raw: when not True, return the section without interpolation,
+        application of defaults, or other alteration.
+
     :returns: A ``dict`` of settings. This should return a dictionary object
         even if no data is available.
 
     """
     loader = get_loader(config_uri)
 
-    return loader.get_settings(section, defaults)
+    return loader.get_settings(section, defaults, raw=raw)
 
 
 def setup_logging(config_uri, defaults=None):

--- a/tests/fake_packages/app1/app1/loaders.py
+++ b/tests/fake_packages/app1/app1/loaders.py
@@ -13,10 +13,10 @@ class LoaderBase(plaster.ILoader):
     def get_sections(self):
         return list(_SECTIONS.keys())
 
-    def get_settings(self, section=None, defaults=None):
+    def get_settings(self, section=None, defaults=None, *, raw=False):
         if section is None:
             section = self.uri.fragment
-        if defaults is not None:
+        if defaults is not None and not raw:
             result = defaults.copy()
         else:
             result = {}

--- a/tests/fake_packages/app2/app2/loaders.py
+++ b/tests/fake_packages/app2/app2/loaders.py
@@ -12,10 +12,10 @@ class LoaderBase(plaster.ILoader):
     def get_sections(self):
         return list(_SECTIONS.keys())
 
-    def get_settings(self, section=None, defaults=None):
+    def get_settings(self, section=None, defaults=None, *, raw=False):
         if section is None:
             section = self.uri.fragment
-        if defaults is not None:
+        if defaults is not None and not raw:
             result = defaults.copy()
         else:
             result = {}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -141,36 +141,40 @@ class Test_get_sections:
             self._callFUT("development.bad")
 
 
+@pytest.mark.parametrize("raw", [False, True])
 @pytest.mark.usefixtures("fake_packages")
 class Test_get_settings:
-    def _callFUT(self, config_uri, section=None, defaults=None):
+    def _callFUT(self, config_uri, section=None, defaults=None, *, raw=False):
         from plaster.loaders import get_settings
 
-        return get_settings(config_uri, section=section, defaults=defaults)
+        return get_settings(config_uri, section=section, defaults=defaults, raw=raw)
 
-    def test_it_explicit_a(self):
-        result = self._callFUT("development.ini", "a")
+    def test_it_explicit_a(self, raw):
+        result = self._callFUT("development.ini", "a", raw=raw)
         assert result == {"foo": "bar"}
 
-    def test_it_explicit_b(self):
-        result = self._callFUT("development.ini", "b")
+    def test_it_explicit_b(self, raw):
+        result = self._callFUT("development.ini", "b", raw=raw)
         assert result == {"baz": "xyz"}
 
-    def test_it_fragment(self):
-        result = self._callFUT("development.ini#a")
+    def test_it_fragment(self, raw):
+        result = self._callFUT("development.ini#a", raw=raw)
         assert result == {"foo": "bar"}
 
-    def test_defaults(self):
-        result = self._callFUT("development.ini", "a", {"baz": "foo"})
-        assert result == {"foo": "bar", "baz": "foo"}
+    def test_defaults(self, raw):
+        result = self._callFUT("development.ini", "a", {"baz": "foo"}, raw=raw)
+        if raw:
+            assert result == {"foo": "bar"}
+        else:
+            assert result == {"foo": "bar", "baz": "foo"}
 
-    def test_invalid_section(self):
-        result = self._callFUT("development.ini", "c")
+    def test_invalid_section(self, raw):
+        result = self._callFUT("development.ini", "c", raw=raw)
         assert result == {}
 
-    def test_it_bad(self):
+    def test_it_bad(self, raw):
         with pytest.raises(Exception):
-            self._callFUT("development.bad")
+            self._callFUT("development.bad", raw=raw)
 
 
 @pytest.mark.usefixtures("fake_packages")


### PR DESCRIPTION
Hi,

This makes it possible to copy configurations and avoid multiple interpolations, or interpolation errors.

In a pyramid-cookiecutter-starter patch I pull out configuration from a yaml file and load it into an configparser.Config() configuration, or simply pull configuration from an ini file and load it into alembic's configuration.  (No reason to write different code for yaml and ini config file sources).:
https://github.com/kpinc/pyramid-cookiecutter-starter/blob/fad9192058e950b17c3e2f0232729e69bdc4984b/%7B%7Bcookiecutter.repo_name%7D%7D/tests/sqlalchemy_conftest.py#L37
https://github.com/kpinc/pyramid-cookiecutter-starter/blob/fad9192058e950b17c3e2f0232729e69bdc4984b/%7B%7Bcookiecutter.repo_name%7D%7D/tests/sqlalchemy_conftest.py#L48


It seems like an important feature, even if pyramid-cookiecutter-starter, enhanced to support yaml config files, might somehow not need to use it.